### PR TITLE
Fixes the go mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/shopsmart/opensearchconfig
+module github.com/shopsmart/opensearchconfig-go
 
 go 1.19
 


### PR DESCRIPTION
## Problem

<!-- What are you trying to solve? -->

```
go get github.com/shopsmart/opensearchconfig-go
go: github.com/shopsmart/opensearchconfig-go@v1.0.0: parsing go.mod:
	module declares its path as: github.com/shopsmart/opensearchconfig
	        but was required as: github.com/shopsmart/opensearchconfig-go
```

## Solution

<!-- How does this change fix the problem? -->

Uses the correct module name in the go mod.
