### PR TITLE
Replaces all occurrences of set-output with new syntax

### DIFF
--- a/.github/workflows/verify-pull-request.yml
+++ b/.github/workflows/verify-pull-request.yml
@@ -24,15 +24,17 @@ jobs:
       - name: 'Checkout'
         uses: actions/checkout@v3
 
-      - uses: actions/setup-go@v3
+      - name: 'Setup go'
+        uses: actions/setup-go@v3
         with:
           go-version-file: go.mod
           cache-file: go.sum
 
-      - name: go test -v ./...
+      - name: 'Run tests'
+        run: go test -v ./...
 
-  precommit:
-    name: Run precommit check
+  pre-commit:
+    name: 'Run pre-commit check'
     runs-on: ubuntu-latest
     if: github.event.repository.name != 'go-template'
     steps:

--- a/.github/workflows/verify-pull-request.yml
+++ b/.github/workflows/verify-pull-request.yml
@@ -21,20 +21,13 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.repository.name != 'go-template'
     steps:
-      - uses: actions/checkout@v2
+      - name: 'Checkout'
+        uses: actions/checkout@v3
 
-      - name: Get Go Version
-        id: goversion
-        run: |
-          set -eo pipefail
-          version="$(< .go-version)"
-          echo "::set-output name=version::$version"
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v3
         with:
-          go-version: ${{ steps.goversion.outputs.version }}
-
-      - name: Install dependencies
-        run: go mod download
+          go-version-file: go.mod
+          cache-file: go.sum
 
       - name: go test -v ./...
 
@@ -43,18 +36,14 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.repository.name != 'go-template'
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - name: 'Checkout'
+        uses: actions/checkout@v3
 
-      - name: Get Go Version
-        id: goversion
-        run: |
-          set -eo pipefail
-          version="$(< .go-version)"
-          echo "::set-output name=version::$version"
-      - uses: actions/setup-go@v2
+      - name: 'Setup go'
+        uses: actions/setup-go@v3
         with:
-          go-version: ${{ steps.goversion.outputs.version }}
+          go-version-file: go.mod
+          cache-file: go.sum
 
-      - name: Run pre-commit check
-        uses: pre-commit/action@v2.0.0
+      - name: 'Run pre-commit check'
+        uses: pre-commit/action@v3.0.0


### PR DESCRIPTION
## Problem

<!-- What are you trying to solve? -->

Github actions has replaced `::set-output name=$name::$value` with `echo $name=$value >> $GITHUB_OUTPUT`.

## Solution

<!-- How does this change fix the problem? -->

Updates set output syntax.

## Notes

<!-- Additional information to include -->


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204180254215591