### PR TITLE
Name the service for datadog tracing

### DIFF
--- a/opensearchconfig.go
+++ b/opensearchconfig.go
@@ -26,6 +26,8 @@ const (
 	AuthIAM = "iam"
 	// ENV variable to control whether traces are send to datadog
 	DD_TRACE_ENABLED = "DD_TRACE_ENABLED"
+	// Identify the name of the trace in datadog
+	Opensearch = "opensearch"
 )
 
 var (
@@ -89,7 +91,11 @@ func ConfigFromEnv(ctx context.Context) (opensearch.Config, error) {
 	}
 
 	if os.Getenv(DD_TRACE_ENABLED) == "true" {
-		opensearchConfig.Transport = httptrace.WrapRoundTripper(opensearchConfig.Transport)
+		opts := httptrace.RTWithServiceName(Opensearch)
+		opensearchConfig.Transport = httptrace.WrapRoundTripper(
+			opensearchConfig.Transport,
+			opts,
+		)
 	}
 
 	switch cfg.Auth {

--- a/opensearchconfig.go
+++ b/opensearchconfig.go
@@ -91,13 +91,17 @@ func ConfigFromEnv(ctx context.Context) (opensearch.Config, error) {
 	}
 
 	if os.Getenv(DD_TRACE_ENABLED) == "true" {
-		opts := httptrace.RTWithSpanNamer(func(req *http.Request) string {
+		var opts []httptrace.RoundTripperOption
+		opts = append(opts, httptrace.RTWithSpanNamer(func(req *http.Request) string {
 			return Opensearch
-		})
+		}))
+		opts = append(opts, httptrace.RTWithResourceNamer(func(req *http.Request) string {
+			return Opensearch
+		}))
 
 		opensearchConfig.Transport = httptrace.WrapRoundTripper(
 			opensearchConfig.Transport,
-			opts,
+			opts...,
 		)
 	}
 

--- a/opensearchconfig.go
+++ b/opensearchconfig.go
@@ -91,9 +91,10 @@ func ConfigFromEnv(ctx context.Context) (opensearch.Config, error) {
 	}
 
 	if os.Getenv(DD_TRACE_ENABLED) == "true" {
-		opts := httptrace.RTWithResourceNamer(func(req *http.Request) string {
+		opts := httptrace.RTWithSpanNamer(func(req *http.Request) string {
 			return Opensearch
 		})
+
 		opensearchConfig.Transport = httptrace.WrapRoundTripper(
 			opensearchConfig.Transport,
 			opts,

--- a/opensearchconfig.go
+++ b/opensearchconfig.go
@@ -27,7 +27,7 @@ const (
 	// ENV variable to control whether traces are send to datadog
 	DD_TRACE_ENABLED = "DD_TRACE_ENABLED"
 	// Identify the name of the trace in datadog
-	Opensearch = "Opensearch"
+	Opensearch = "opensearch"
 )
 
 var (

--- a/opensearchconfig.go
+++ b/opensearchconfig.go
@@ -27,7 +27,7 @@ const (
 	// ENV variable to control whether traces are send to datadog
 	DD_TRACE_ENABLED = "DD_TRACE_ENABLED"
 	// Identify the name of the trace in datadog
-	Opensearch = "opensearch"
+	Opensearch = "Opensearch"
 )
 
 var (
@@ -92,9 +92,6 @@ func ConfigFromEnv(ctx context.Context) (opensearch.Config, error) {
 
 	if os.Getenv(DD_TRACE_ENABLED) == "true" {
 		var opts []httptrace.RoundTripperOption
-		opts = append(opts, httptrace.RTWithSpanNamer(func(req *http.Request) string {
-			return Opensearch
-		}))
 		opts = append(opts, httptrace.RTWithResourceNamer(func(req *http.Request) string {
 			return Opensearch
 		}))

--- a/opensearchconfig.go
+++ b/opensearchconfig.go
@@ -91,7 +91,9 @@ func ConfigFromEnv(ctx context.Context) (opensearch.Config, error) {
 	}
 
 	if os.Getenv(DD_TRACE_ENABLED) == "true" {
-		opts := httptrace.RTWithServiceName(Opensearch)
+		opts := httptrace.RTWithResourceNamer(func(req *http.Request) string {
+			return Opensearch
+		})
 		opensearchConfig.Transport = httptrace.WrapRoundTripper(
 			opensearchConfig.Transport,
 			opts,


### PR DESCRIPTION
## Problem

In datadog these requests show up as http.Request instead of Opensearch

## Solution

Name the resource Opensearch so traces show up named accordingly.
